### PR TITLE
Avoid warning message in console upon page load

### DIFF
--- a/chromeiql.html
+++ b/chromeiql.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="css/chromeiql.css" />
   </head>
   <body>
-    Loading...
+    <div id="react-container">Loading...</div>
     <script src="dist/chromeiql.js"></script>
   </body>
 </html>

--- a/css/chromeiql.css
+++ b/css/chromeiql.css
@@ -1,10 +1,6 @@
-html {
-  width: 100%;
-  height: 100%;
-  margin: 0;
-}
-
-body {
+html,
+body,
+#react-container {
   width: 100%;
   height: 100%;
   margin: 0;

--- a/js/chromeiql.jsx
+++ b/js/chromeiql.jsx
@@ -131,9 +131,9 @@ class ChromeiQL extends React.Component {
 }
 
 chrome.storage.local.get("chromeiqlEndpoint", (storage) =>
-  // Render <GraphiQL /> into the body.
+  // Render <GraphiQL /> into the container.
   ReactDOM.render(
     <ChromeiQL endpoint={storage.chromeiqlEndpoint} />,
-    document.body
+    document.getElementById('react-container')
   )
 );


### PR DESCRIPTION
We used to have a message in console warning against rendering in the body. To avoid that we now render in a dedicated react container.
    
The warning was: `Rendering components directly into document.body is discouraged`
