### PR TITLE
Add introspection query

### DIFF
--- a/js/chromeiql.jsx
+++ b/js/chromeiql.jsx
@@ -52,6 +52,10 @@ function updateURL() {
 // Defines a GraphQL fetcher using the fetch API.
 function graphQLFetcher(endpoint) {
   return function(graphQLParams) {
+    if (graphQLParams.query.indexOf('query IntrospectionQuery') > -1) {
+      graphQLParams.operationName = 'IntrospectionQuery'
+    }
+
     return fetch(endpoint, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Hi, I found a small issue, related to the default behavior of graphql. Here is an explanation of this issue:

### Explanation

Let's make a test open extension fill `Set endpoint` field with correct graphql endpoint and cicck to button. In this case extension will send request like the next:

```
"params" = { 
"query" => "\n  query IntrospectionQuery {\n    __schema {\n      queryType { name }\n      mutationType { name }\n      types {\n        ...FullType\n      }\n      directives {\n        name\n        description\n        locations\n        args {\n          ...InputValue\n        }\n      }\n    }\n  }\n\n  fragment FullType on __Type {\n    kind\n    name\n    description\n    fields(includeDeprecated: true) {\n      name\n      description\n      args {\n        ...InputValue\n      }\n      type {\n        ...TypeRef\n      }\n      isDeprecated\n      deprecationReason\n    }\n    inputFields {\n      ...InputValue\n    }\n    interfaces {\n      ...TypeRef\n    }\n    enumValues(includeDeprecated: true) {\n      name\n      description\n      isDeprecated\n      deprecationReason\n    }\n    possibleTypes {\n      ...TypeRef\n    }\n  }\n\n  fragment InputValue on __InputValue {\n    name\n    description\n    type { ...TypeRef }\n    defaultValue\n  }\n\n  fragment TypeRef on __Type {\n    kind\n    name\n    ofType {\n      kind\n      name\n      ofType {\n        kind\n        name\n        ofType {\n          kind\n          name\n          ofType {\n            kind\n            name\n            ofType {\n              kind\n              name\n              ofType {\n                kind\n                name\n                ofType {\n                  kind\n                  name\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n" 
}
```

We see only one field `query`. Let's make the next, copy body of this query to graphiql explorer and click `Execute Query` button (don't forget delete \n symbols). In this case, extension will send the next parameters:

```
params = {
    "query" => "query IntrospectionQuery {    __schema {      queryType { name }      mutationType { name }      types {        ...FullType      }      directives {        name        description        locations        args {          ...InputValue        }      }    }  }  fragment FullType on __Type {    kind    name    description    fields(includeDeprecated: true) {      name      description      args {        ...InputValue      }      type {        ...TypeRef      }      isDeprecated      deprecationReason    }    inputFields {      ...InputValue    }    interfaces {      ...TypeRef    }    enumValues(includeDeprecated: true) {      name      description      isDeprecated      deprecationReason    }    possibleTypes {      ...TypeRef    }  }  fragment InputValue on __InputValue {    name    description    type { ...TypeRef }    defaultValue  }  fragment TypeRef on __Type {    kind    name    ofType {      kind      name      ofType {        kind        name        ofType {          kind          name          ofType {            kind            name            ofType {              kind              name              ofType {                kind                name                ofType {                  kind                  name                }              }            }          }        }      }    }  }",
    "variables" => nil,
    "operationName" => "IntrospectionQuery",
}
```

Most important difference between these parameters is `operationName` parameter. Our backend uses this parameter and other backend's could use too. 

To avoid this issue I created this PR.

Also, I don't want to create an additional extension in google store and increase confusing, because I created this PR.